### PR TITLE
Reseacher typo

### DIFF
--- a/www.divd.nl/_includes/posts-cases.html
+++ b/www.divd.nl/_includes/posts-cases.html
@@ -8,7 +8,7 @@
 {% endfor %}
 
 {% for c in site.cases %}
-  {% if c.author contains include.name or c.lead == include.name or c.reseachers contains include.name %}
+  {% if c.author contains include.name or c.lead == include.name or c.researchers contains include.name %}
     {% assign found = true %}
     {% assign cases = true %}
   {% endif %}
@@ -22,7 +22,7 @@
 {% endfor %}
 
 {% for c in site.cves %}
-  {% if c.author == include.name or c.discovered_by contains include.name or c.reseachers contains include.name %}
+  {% if c.author == include.name or c.discovered_by contains include.name or c.researchers contains include.name %}
     {% assign found = true %}
     {% assign cve = true %}
     {% if c.discovered_by contains include.name %}
@@ -60,7 +60,7 @@
     <ul>
       {% assign rev_cases = site.cases | reverse %}
       {% for c in rev_cases %}
-        {% if c.author contains include.name or c.lead == include.name or c.reseachers contains include.name %}
+        {% if c.author contains include.name or c.lead == include.name or c.researchers contains include.name %}
           <li>
             <a href='https://csirt.divd.nl/{{ c.divd }}'>{{ c.title }}</a>
           </li>
@@ -90,7 +90,7 @@
       {% for c in site.cves %}
         {% if c.discovered_by contains include.name %}
         {% else %}
-          {% if c.author == include.name or c.reseachers contains include.name %}
+          {% if c.author == include.name or c.researchers contains include.name %}
             <li>
               <a href='https://csirt.divd.nl{{ c.url }}'>{{ c.cve | escape }} - {{ c.title | escape }}</a>
             </li>


### PR DESCRIPTION
By replacing reseacher with (the correct) researcher, the template now picks
up more authors than it would before, making the team-pages more complete

This was mentioned in https://github.com/DIVD-NL/sites/issues/35 already, but 
never patched