### PR TITLE
Remove outdated releasenotes

### DIFF
--- a/csirt.divd.nl/cases/DIVD-2021-00027.md
+++ b/csirt.divd.nl/cases/DIVD-2021-00027.md
@@ -48,6 +48,5 @@ We are actively scanning for vulnerable machines on the internet.
 
 ## More information
 * [Path Traversal Zero-Day in Apache HTTP Server Exploited](https://www.tenable.com/blog/cve-2021-41773-path-traversal-zero-day-in-apache-http-server-exploited)
-* [Apache 2.4.50 Release Notes](https://downloads.apache.org/httpd/CHANGES_2.4.50)
 * [Apache fixes actively exploited web server zero-day](https://therecord.media/apache-fixes-actively-exploited-web-server-zero-day/)
 * [NCSC Advisory NCSC-2021-0861](https://advisories.ncsc.nl/advisory?id=NCSC-2021-0861)


### PR DESCRIPTION
It seems Apache has only changelogfiles for pointreleases (2.4.50) for their last release, not for previous ones. Those are merged into one big one (changelog 2.4) -- removing this dead link