### PR TITLE
Added whole timeline + closing case

### DIFF
--- a/_cases/2023/DIVD-2023-00006.md
+++ b/_cases/2023/DIVD-2023-00006.md
@@ -40,6 +40,7 @@ timeline:
 - start: 2023-03-22
   end:
   event: "DIVD closes case"
+ips: n/a
 ---
 
 ## Summary

--- a/_cases/2023/DIVD-2023-00006.md
+++ b/_cases/2023/DIVD-2023-00006.md
@@ -3,7 +3,7 @@ layout: case
 title: "Unauthenticated code injection in QNAP QTS and QuTS hero"
 author: Stan Plasmeijer
 lead: Stan Plasmeijer
-status: Open
+status: Closed
 excerpt: "QNAP has released an advisory for devices running QTS 5.0.1 and QuTS hero h5.0.1. Those devices might be vulnerable for code injection."
 researchers:
 - Rutger Hermens
@@ -17,11 +17,29 @@ versions:
 
 recommendation: "If you have a vulnerable QTS or QuTS hero, update to the latest version."
 start: 2023-02-02
-end:
+end: 2023-03-22
 timeline:
 - start: 2023-02-02
   end:
   event: "DIVD starts researching fingerprint."
+- start: 2023-02-08
+  end:
+  event: "DIVD conducts first scan."
+- start: 2023-02-09
+  end:
+  event: "First scan finished, no vulnerable instances found."
+- start: 2023-02-15
+  end:
+  event: "DIVD parsed the scan results of case [DIVD-2022-00030](https://csirt.divd.nl/cases/DIVD-2022-00030/). We didn't find any devices running QTS 5.0.1 and QuTS hero h5.0.1"
+- start: 2023-03-22
+  end:
+  event: "DIVD conducts second scan."
+- start: 2023-03-22
+  end:
+  event: "Second scan finished, no vulnerable instances found."
+- start: 2023-03-22
+  end:
+  event: "DIVD closes case"
 ---
 
 ## Summary
@@ -44,4 +62,3 @@ The notificaiton will be sent to the party responsible for the ip address accoor
 * {% cve CVE-2022-27596 %}
 * [ManageEngine Security Advisory](https://www.qnap.com/en/security-advisory/qsa-23-01)
 * [Censys Article](https://censys.io/cve-2022-27596/)
-


### PR DESCRIPTION
Added the whole timeline + closing the case. No vulnerable instances found in multiple scans.

After the first scan, QNAP changed the affacted versions. This resulted in less vulnerable instances found by Censys. Instead of 67480 vulnerable instances found, only 557 showed up. Of the 557, we found none.