### PR TITLE
Update scanners.yml

### DIFF
--- a/_data/scanners.yml
+++ b/_data/scanners.yml
@@ -1,6 +1,2 @@
 - name: AS50559
   description: "IPv4: 194.5.73.0/24 aka 194.5.73.0-194.5.73.255 - Our own local infrastructure"
-- name: Cyberwar.nl
-  description: "IPv4: 149.210.129.7 - Operated by Matthijs Koot"
-- name: log4jdns.x00.it
-  description: "IPv4: 5.2.67.229 - We use this domain and DNS server to track log4j vulnerabilities"


### PR DESCRIPTION
Removed legacy scanners:

Cyberwar.nl
IPv4: 149.210.129.7 - Operated by Matthijs Koot

log4jdns.x00.it
IPv4: 5.2.67.229 - We use this domain and DNS server to track log4j vulnerabilities
